### PR TITLE
Use environment variable for API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GOOGLE_API_KEY=your_key

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # visor-de-tiendas
+
+Esta aplicacion usa la API de Google Places para buscar tiendas.
+
+## Variables de entorno
+
+Debes definir `GOOGLE_API_KEY` con tu clave de la API. Puedes crear un archivo `.env` basado en `.env.example`:
+
+```
+GOOGLE_API_KEY=your_key
+```

--- a/runner.py
+++ b/runner.py
@@ -6,7 +6,9 @@ from geocoding import obtener_coordenadas_y_radio
 from places_search import buscar_lugares
 
 TIENDAS_FILE = "tiendas_guardadas.json"
-API_KEY = "AIzaSyBOcCSXuwaRlQ3s0ttDcMOLBswCMjzsRYg"  
+API_KEY = os.getenv("GOOGLE_API_KEY")
+if not API_KEY:
+    raise RuntimeError("Missing GOOGLE_API_KEY environment variable")
 
 def guardar_tiendas_formateadas(memoria):
     datos = {}


### PR DESCRIPTION
## Summary
- load GOOGLE_API_KEY from environment in `runner.py`
- document the variable in README
- provide `.env.example` template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684767a1553883208e9942ec61f3987d